### PR TITLE
v 1.3.1 - add verify false to Guzzle

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Or add the package to your `composer.json`:
 ```json
 {
     "require": {
-        "infusionweb/laravel-remote-content-cache": "~1.3.0"
+        "infusionweb/laravel-remote-content-cache": "~1.3.1"
     }
 }
 ```

--- a/src/ContentCache/ContentCache.php
+++ b/src/ContentCache/ContentCache.php
@@ -46,7 +46,13 @@ class ContentCache
         $query['limit'] = $limit;
         $query['offset'] = $offset;
 
-        $response = Guzzle::get( $profile->getEndpoint(), ['query' => $query] );
+        $response = Guzzle::get(
+            $profile->getEndpoint(),
+            [
+                'query' => $query,
+                'verify' => false,
+            ],
+        );
 
         $result = json_decode($response->getBody());
         if (is_object($result) && property_exists($result, 'results') && is_array($result->results)) {


### PR DESCRIPTION
I added verify false because Curl kept having SSL issues - see https://keap.slack.com/archives/C02GBPYC1B7/p1658195617923089